### PR TITLE
Add command line interface

### DIFF
--- a/chembl_structure_pipeline/chembl_std.py
+++ b/chembl_structure_pipeline/chembl_std.py
@@ -1,0 +1,115 @@
+from rdkit import RDLogger
+from rdkit.Chem.FilterCatalog import FilterCatalog, FilterCatalogParams
+from rdkit import Chem
+import argparse
+import warnings
+import sys
+warnings.simplefilter('ignore', category=RuntimeWarning)
+
+
+class RunningException(Exception):
+    pass
+
+
+class MolFromSmiles(RunningException):
+    pass
+
+
+class HasPains(RunningException):
+    pass
+
+
+class CouldNotBeStandartized(RunningException):
+    pass
+
+
+class Filter:
+    p = FilterCatalogParams.FilterCatalogs.PAINS
+    A = FilterCatalogParams.FilterCatalogs.PAINS_A
+    B = FilterCatalogParams.FilterCatalogs.PAINS_B
+    C = FilterCatalogParams.FilterCatalogs.PAINS_C
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Sanitize smiles using chembl_structure_pipeline and RDKit PAINS filters',
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument('-s', '--standartize', action='store_true', default=True,
+                        help='Whether to perform standartization of input SMILES')
+    parser.add_argument('-p', action='store_true', default=True,
+                        help='Filter molecules using all PAINS filters together')
+    parser.add_argument('-A', action='store_true', default=False,
+                        help='Filter molecules using all PAINS_A filter separately')
+    parser.add_argument('-B', action='store_true', default=False,
+                        help='Filter molecules using all PBINS_B filter separately')
+    parser.add_argument('-C', action='store_true', default=False,
+                        help='Filter molecules using all PCINS_C filter separately')
+    parser.add_argument('input', metavar='INPUT',
+                        help='Input file (with SMILES as first column)')
+    parser.add_argument('--strict', action='store_true', default=False,
+                        help='Whether to raise an exception on first error')
+    parser.add_argument('--header', action='store_true', default=False,
+                        help='Indicate that the input file contains header')
+    parser.add_argument('--verbose', action='store_true', default=False,
+                        help='Whether to print all RDKit warnings to stdout')
+    parser.add_argument('--stderr', action='store_true', default=False,
+                        help='Whether to print filtered molecules to stderr')
+    args = parser.parse_args()
+    if not args.verbose:
+        from rdkit.rdBase import BlockLogs
+        block = BlockLogs()
+        RDLogger.DisableLog('rdApp.*')
+
+    params = FilterCatalogParams()
+    if args.p:
+        params.AddCatalog(Filter.p)
+    if args.A:
+        params.AddCatalog(Filter.A)
+    if args.B:
+        params.AddCatalog(Filter.B)
+    if args.C:
+        params.AddCatalog(Filter.C)
+    catalog = FilterCatalog(params)
+
+    def has_pains(mol):
+        entry = catalog.GetFirstMatch(mol)
+        return bool(entry), entry  # will be empty if no match found
+
+    with open(args.input, 'r') as fin:
+        from chembl_structure_pipeline import standardize_mol
+
+        if args.header:
+            line = next(fin)
+            print(line, end='')
+
+        for idx, line in enumerate(fin):
+            smiles = line.strip().split(maxsplit=1)[0]
+            try:
+                mol = Chem.MolFromSmiles(smiles)
+                if not mol:
+                    raise MolFromSmiles(
+                        'Line {}, SMILES: {}'.format(idx, smiles))
+
+                mol_std = standardize_mol(mol)
+                if not mol_std:
+                    raise CouldNotBeStandartized(
+                        'Line {}, SMILES: {}'.format(idx, smiles))
+
+                result, entry = has_pains(mol_std)
+                if result:
+                    group = entry.GetProp('Scope')
+                    raise HasPains(
+                        'Line {}, SMILES: {}, type: {}'.format(idx, smiles, group))
+
+                print(line, end='')
+
+            except RunningException:
+                if args.strict:
+                    raise
+                if args.stderr:
+                    print(line, end='', file=sys.stderr)
+
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -10,4 +10,9 @@ setup(name='chembl_structure_pipeline',
       license='MIT',
       packages=['chembl_structure_pipeline'],
       package_data={'chembl_structure_pipeline': ['data/*']},
+      entry_points = {
+        'console_scripts': 
+        ['chembl_std=chembl_structure_pipeline.chembl_std:main'],
+      },
+
       zip_safe=False)


### PR DESCRIPTION
Hi everyone,

as mentioned in #14 , I've added a command line interface to standartization from SMILES strings (namely, from input files containing SMILES as their first column). Also, I added an option to filter compounds using PAINS filters in RDKit as [here](https://www.rdkit.org/docs/source/rdkit.Chem.rdfiltercatalog.html) -- it might be useful to switch it off by default, if you think it's more appropriate for this package.

The interface is following:

```bash
usage: chembl_std [-h] [-s] [-p] [-A] [-B] [-C] [--strict] [--header] [--verbose] [--stderr] INPUT

Sanitize smiles using chembl_structure_pipeline and RDKit PAINS filters

positional arguments:
  INPUT              Input file (with SMILES as first column)

optional arguments:
  -h, --help         show this help message and exit
  -s, --standartize  Whether to perform standartization of input SMILES (default: True)
  -p                 Filter molecules using all PAINS filters together (default: True)
  -A                 Filter molecules using all PAINS_A filter separately (default: False)
  -B                 Filter molecules using all PBINS_B filter separately (default: False)
  -C                 Filter molecules using all PCINS_C filter separately (default: False)
  --strict           Whether to raise an exception on first error (default: False)
  --header           Indicate that the input file contains header (default: False)
  --verbose          Whether to print all RDKit warnings to stdout (default: False)
  --stderr           Whether to print filtered molecules to stderr (default: False)
```

So in order to filter `test.smi`, one should do the following:

```bash
$ cat test.smi
smiles
c1ccccc1N=Nc1ccccc1
c1ccccc1N
CCO
$ chembl_std --header test.smi
smiles
c1ccccc1N
CCO
```

The downside is that it prints a lot of logging messages to stdout, and I could not completely disable them. For example, if I do `chembl_std --header test.smi > out.smi`, I'd get:

```bash
$ cat out.smi
smiles
c1ccccc1N
CCO
[01:33:17] Initializing Normalizer
```

The current workaround is to do `chembl_std --header test.smi | grep -v Normalizer > out.smi`. If someone knows how to manage it better, I'd appreciate.



