### PR TITLE
Fix installation conflict and add RDKit-pypi as a versioned requirement

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,8 @@
+[bumpversion]
+current_version = 1.0.0
+commit = False
+tag = False
+
+[bumpversion:file:setup.py]
+
+[bumpversion:file:chembl_structure_pipeline/__init__.py]

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Other
+*.DS_Store
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+test:
+	nosetests --with-doctest

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,11 @@
 test:
 	nosetests --with-doctest
+
+increment-minor:
+	bump2version minor --allow-dirty
+
+increment-major:
+	bump2version minor --allow-dirty
+
+increment-patch:
+	bump2version patch --allow-dirty

--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ From source:
     git clone https://github.com/chembl/ChEMBL_Structure_Pipeline.git
     pip install ./ChEMBL_Structure_Pipeline
 
+Using `pip`, the latest compatible version of `rdkit` may be installed at the same time:
+```
+pip install "./ChEMBL_Structure_Pipeline[rdkit]"
+```
+
 Using conda:
 
 ```bash
@@ -90,6 +95,24 @@ M  END
 
 issues = checker.check_molblock(o_molblock)
 ```
+
+## Development
+
+The packages required to develop this tool (`nose` and `bump2version`) may be installed via
+```
+pip install -e ".[dev]"
+```
+
+Tests can be run via
+```
+make test
+```
+
+Versioning this tool can be controlled via:
+```
+make increment-minor
+```
+The increment can be `major`, `minor`, or `patch`, accordingly, and this will update `setup.py` and `chembl_structure_pipeline/__init__.py`.
 
 ## References
 <a id="1">[1]</a> 

--- a/chembl_structure_pipeline/__init__.py
+++ b/chembl_structure_pipeline/__init__.py
@@ -97,9 +97,9 @@ was found:
     >>>
 
 """
-from .checker import check_molblock
-from .standardizer import standardize_molblock, standardize_mol
-from .standardizer import get_parent_molblock, get_parent_mol
+from chembl_structure_pipeline.checker import check_molblock
+from chembl_structure_pipeline.standardizer import standardize_molblock, standardize_mol
+from chembl_structure_pipeline.standardizer import get_parent_molblock, get_parent_mol
 
 #
 #  Copyright (c) 2019 Greg Landrum

--- a/chembl_structure_pipeline/__init__.py
+++ b/chembl_structure_pipeline/__init__.py
@@ -100,6 +100,7 @@ was found:
 from chembl_structure_pipeline.checker import check_molblock
 from chembl_structure_pipeline.standardizer import standardize_molblock, standardize_mol
 from chembl_structure_pipeline.standardizer import get_parent_molblock, get_parent_mol
+__version__ = "1.0.0"
 
 #
 #  Copyright (c) 2019 Greg Landrum

--- a/chembl_structure_pipeline/__init__.py
+++ b/chembl_structure_pipeline/__init__.py
@@ -100,7 +100,6 @@ was found:
 from .checker import check_molblock
 from .standardizer import standardize_molblock, standardize_mol
 from .standardizer import get_parent_molblock, get_parent_mol
-__version__ = "1.0.0"
 
 #
 #  Copyright (c) 2019 Greg Landrum

--- a/chembl_structure_pipeline/test/test_checker.py
+++ b/chembl_structure_pipeline/test/test_checker.py
@@ -6,7 +6,7 @@
 #  The contents are covered by the terms of the MIT license
 #  which is included in the file LICENSE, found at the root
 #  of the source tree.
-from .. import checker
+from chembl_structure_pipeline import checker
 import unittest
 from rdkit import Chem
 

--- a/chembl_structure_pipeline/test/test_standardizer.py
+++ b/chembl_structure_pipeline/test/test_standardizer.py
@@ -6,7 +6,7 @@
 #  The contents are covered by the terms of the MIT license
 #  which is included in the file LICENSE, found at the root
 #  of the source tree.
-from .. import standardizer
+from chembl_structure_pipeline import standardizer
 import unittest
 import math
 import os

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[metadata]
-version = attr: chembl_structure_pipeline.__version__

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[metadata]
+version = attr: chembl_structure_pipeline.__version__

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     packages=["chembl_structure_pipeline"],
     package_data={"chembl_structure_pipeline": ["data/*"]},
     zip_safe=False,
-    install_requires=["setuptools>=46.4.0"],
+    install_requires=["setuptools>=46.4.0", "nose>=1.3.7"],
     extras_require={
         "rdkit": ["rdkit-pypi>=2019.03.1,<=2021.3.5.1"],
     },

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     packages=["chembl_structure_pipeline"],
     package_data={"chembl_structure_pipeline": ["data/*"]},
     zip_safe=False,
-    install_requires=[
-          "rdkit-pypi>=2019.03.1,<=2022.3.1"
-    ]
+    extras_require={
+        "rdkit": ["rdkit-pypi>=2019.03.1,<=2021.3.5.1"],
+    },
 )

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@ from setuptools import setup
 
 setup(
     name="chembl_structure_pipeline",
-    version="1.0.0",
     description="ChEMBL Structure Pipeline",
     url="https://www.ebi.ac.uk/chembl/",
     author="Greg Landrum",
@@ -11,6 +10,7 @@ setup(
     packages=["chembl_structure_pipeline"],
     package_data={"chembl_structure_pipeline": ["data/*"]},
     zip_safe=False,
+    install_requires=["setuptools>=46.4.0"],
     extras_require={
         "rdkit": ["rdkit-pypi>=2019.03.1,<=2021.3.5.1"],
     },

--- a/setup.py
+++ b/setup.py
@@ -11,4 +11,7 @@ setup(
     packages=["chembl_structure_pipeline"],
     package_data={"chembl_structure_pipeline": ["data/*"]},
     zip_safe=False,
+    install_requires=[
+          "rdkit-pypi<=2022.3.1"
+    ]
 )

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@ from setuptools import setup
 
 setup(
     name="chembl_structure_pipeline",
+    version="1.0.1",
     description="ChEMBL Structure Pipeline",
     url="https://www.ebi.ac.uk/chembl/",
     author="Greg Landrum",
@@ -13,5 +14,6 @@ setup(
     install_requires=["setuptools>=46.4.0", "nose>=1.3.7"],
     extras_require={
         "rdkit": ["rdkit-pypi>=2019.03.1,<=2021.3.5.1"],
+        "dev": ["bump2version>=1.0.0"]
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,6 @@ setup(
     package_data={"chembl_structure_pipeline": ["data/*"]},
     zip_safe=False,
     install_requires=[
-          "rdkit-pypi<=2022.3.1"
+          "rdkit-pypi>=2019.03.1,<=2022.3.1"
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -11,9 +11,9 @@ setup(
     packages=["chembl_structure_pipeline"],
     package_data={"chembl_structure_pipeline": ["data/*"]},
     zip_safe=False,
-    install_requires=["setuptools>=46.4.0", "nose>=1.3.7"],
+    install_requires=["setuptools>=46.4.0"],
     extras_require={
         "rdkit": ["rdkit-pypi>=2019.03.1,<=2021.3.5.1"],
-        "dev": ["bump2version>=1.0.0"]
+        "dev": ["bump2version<=1.0.0", "nose<=1.3.7"]
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,14 @@
 from setuptools import setup
-import chembl_structure_pipeline
 
-setup(name='chembl_structure_pipeline',
-      version=chembl_structure_pipeline.__version__,
-      description='ChEMBL Structure Pipeline',
-      url='https://www.ebi.ac.uk/chembl/',
-      author='Greg Landrum',
-      author_email='greg.landrum@t5informatics.com',
-      license='MIT',
-      packages=['chembl_structure_pipeline'],
-      package_data={'chembl_structure_pipeline': ['data/*']},
-      zip_safe=False)
+setup(
+    name="chembl_structure_pipeline",
+    version="1.0.0",
+    description="ChEMBL Structure Pipeline",
+    url="https://www.ebi.ac.uk/chembl/",
+    author="Greg Landrum",
+    author_email="greg.landrum@t5informatics.com",
+    license="MIT",
+    packages=["chembl_structure_pipeline"],
+    package_data={"chembl_structure_pipeline": ["data/*"]},
+    zip_safe=False,
+)


### PR DESCRIPTION
This PR fixes some circular import that is encountered during setup/installation, where the version of the structure pipeline is imported from module code. Now it is hard-coded into `setup.py` together with a pinned version of `rdkit`.

This was encountered in Python 3.9.8 when running:
```
pip install -e .
>>...
>>ModuleNotFoundError: No module named 'rdkit'
```
This was due to the setup script imported the version of this pipeline from `chembl_structure_pipeline/__init__.py`, which subsequently required the import of `rdkit` for the other code in `__init__.py`.

Also added `rdkit-pypi` as an optional extra dependency in `setup.py`, since I see in the CI script for this repo that `conda` is used . This should make the PR less likely to cause issues, and enables `pip` to handle versioning, if installed as `pip install -e ".[rdkit]"`

The version of rdkit-pypi is pinned to lie between 2019.03.1 (as specified in the module code) and 2021.3.5.1 (which is the last non-failing version where the tests in #39 still pass - see not below).