### PR TITLE
add sanitize param to standardizer.standardize_mol

### DIFF
--- a/chembl_structure_pipeline/standardizer.py
+++ b/chembl_structure_pipeline/standardizer.py
@@ -452,7 +452,7 @@ def get_parent_molblock(ctab, neutralize=True, check_exclusion=True, verbose=Fal
     return Chem.MolToMolBlock(parent, kekulize=False), exclude
 
 
-def standardize_mol(m, check_exclusion=True):
+def standardize_mol(m, check_exclusion=True, sanitize=True):
     if check_exclusion:
         exclude = exclude_flag(m, includeRDKitSanitization=False)
     else:
@@ -466,6 +466,8 @@ def standardize_mol(m, check_exclusion=True):
         m = uncharge_mol(m)
         m = flatten_tartrate_mol(m)
         m = cleanup_drawing_mol(m)
+        if sanitize:
+            Chem.SanitizeMol(m)
 
     return m
 
@@ -508,4 +510,4 @@ def standardize_molblock(ctab, check_exclusion=True):
     if check_exclusion:
         if exclude_flag(m, includeRDKitSanitization=False):
             return ctab
-    return Chem.MolToMolBlock(standardize_mol(m, check_exclusion=False))
+    return Chem.MolToMolBlock(standardize_mol(m, check_exclusion=False, sanitize=False))

--- a/chembl_structure_pipeline/test/test_standardizer.py
+++ b/chembl_structure_pipeline/test/test_standardizer.py
@@ -3383,3 +3383,22 @@ M  END
         self.assertEqual(
             Chem.MolToSmiles(om), "CCC.O=C(O)C(O)C(O)C(=O)O.O=C(O)C(O)C(O)C(=O)O"
         )
+
+    def testGithub16(self):
+
+        m1 = standardizer.standardize_mol(
+            Chem.MolFromSmiles("CC(=O)N1CCN(Cc2c(Cl)c(F)c(-c3ncnc(C)c3)cc2)CC1")
+        )
+        m2 = standardizer.standardize_mol(
+            Chem.MolFromSmiles("CC(=O)N1CCN(Cc2ccc(-c3cc(C)ncn3)c(F)c2Cl)CC1")
+        )
+        self.assertEqual(Chem.MolToSmiles(m1), Chem.MolToSmiles(m2))
+        m1 = standardizer.standardize_mol(
+            Chem.MolFromSmiles("CC(=O)N1CCN(Cc2c(Cl)c(F)c(-c3ncnc(C)c3)cc2)CC1"),
+            sanitize=False,
+        )
+        m2 = standardizer.standardize_mol(
+            Chem.MolFromSmiles("CC(=O)N1CCN(Cc2ccc(-c3cc(C)ncn3)c(F)c2Cl)CC1"),
+            sanitize=False,
+        )
+        self.assertNotEqual(Chem.MolToSmiles(m1), Chem.MolToSmiles(m2))


### PR DESCRIPTION
Potential fix for issue #16. At ChEMBL we directly use the [standardize_molblock](https://github.com/chembl/ChEMBL_Structure_Pipeline/blob/master/chembl_structure_pipeline/standardizer.py#L506) function so we are happy with adding this small change.

any comment @greglandrum? I took the [rdkit issue](https://github.com/rdkit/rdkit/issues/3094) SMILES example as a test case but I'm not sure it is the best example.