### PR TITLE
Visualization for the ChEMBL_Structure_Pipeline

### DIFF
--- a/.codeboarding/Exclusion Flag Utility.md
+++ b/.codeboarding/Exclusion Flag Utility.md
@@ -1,0 +1,111 @@
+```mermaid
+
+graph LR
+
+    ExclusionFlagService["ExclusionFlagService"]
+
+    FragmentParentMolRetrieval["FragmentParentMolRetrieval"]
+
+    MoleculeStandardization["MoleculeStandardization"]
+
+    MolblockStandardization["MolblockStandardization"]
+
+    FragmentParentMolRetrieval -- "calls" --> ExclusionFlagService
+
+    MoleculeStandardization -- "calls" --> ExclusionFlagService
+
+    MolblockStandardization -- "calls" --> ExclusionFlagService
+
+    MolblockStandardization -- "calls" --> MoleculeStandardization
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+This system provides a comprehensive set of utilities for standardizing chemical structures, including functions to exclude undesirable structures based on predefined criteria, retrieve parent molecules from fragments, and standardize molecules from various input formats like molblocks. The core functionality revolves around ensuring chemical structures meet specific quality and format standards for further processing.
+
+
+
+### ExclusionFlagService
+
+Provides a utility function to determine if a chemical structure should be excluded based on predefined criteria, such as the presence of metallic atoms, a high count of boron atoms, or RDKit sanitization failures. It acts as a gatekeeper for molecular processing.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/chembl/ChEMBL_Structure_Pipeline/blob/master/chembl_structure_pipeline/exclude_flag.py#L84-L113" target="_blank" rel="noopener noreferrer">`chembl_structure_pipeline.exclude_flag.exclude_flag` (84:113)</a>
+
+
+
+
+
+### FragmentParentMolRetrieval
+
+Responsible for retrieving the parent molecule from a set of fragments, handling solvent and salt removal, and optionally neutralizing the molecule. It utilizes the ExclusionFlagService to check if the molecule should be excluded from further processing.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/chembl/ChEMBL_Structure_Pipeline/blob/master/chembl_structure_pipeline/standardizer.py#L290-L427" target="_blank" rel="noopener noreferrer">`chembl_structure_pipeline.standardizer.get_fragment_parent_mol` (290:427)</a>
+
+
+
+
+
+### MoleculeStandardization
+
+Standardizes a given molecule by applying a series of transformations including updating valences, removing s-groups, kekulizing, removing hydrogens, normalizing, uncharging, flattening tartrates, and cleaning up drawing. It utilizes the ExclusionFlagService for an initial exclusion check.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/chembl/ChEMBL_Structure_Pipeline/blob/master/chembl_structure_pipeline/standardizer.py#L455-L472" target="_blank" rel="noopener noreferrer">`chembl_structure_pipeline.standardizer.standardize_mol` (455:472)</a>
+
+
+
+
+
+### MolblockStandardization
+
+Handles the standardization of molecules provided in molblock format. It parses the molblock, utilizes the ExclusionFlagService for an exclusion check, and then uses the MoleculeStandardization component to process the molecule before converting the standardized molecule back into a molblock.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/chembl/ChEMBL_Structure_Pipeline/blob/master/chembl_structure_pipeline/standardizer.py#L508-L513" target="_blank" rel="noopener noreferrer">`chembl_structure_pipeline.standardizer.standardize_molblock` (508:513)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Structure Standardization.md
+++ b/.codeboarding/Structure Standardization.md
@@ -1,0 +1,167 @@
+```mermaid
+
+graph LR
+
+    StandardizationCore["StandardizationCore"]
+
+    ParentMoleculeGenerator["ParentMoleculeGenerator"]
+
+    DrawingCleanup["DrawingCleanup"]
+
+    MolblockProcessor["MolblockProcessor"]
+
+    ExclusionFlag["ExclusionFlag"]
+
+    StandardizationCore -- "invokes cleanup" --> DrawingCleanup
+
+    StandardizationCore -- "applies exclusion check" --> ExclusionFlag
+
+    ParentMoleculeGenerator -- "applies exclusion check" --> ExclusionFlag
+
+    ParentMoleculeGenerator -- "utilizes standardization utilities" --> StandardizationCore
+
+    MolblockProcessor -- "orchestrates standardization" --> StandardizationCore
+
+    MolblockProcessor -- "retrieves parent molecule" --> ParentMoleculeGenerator
+
+    MolblockProcessor -- "applies exclusion check" --> ExclusionFlag
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+The Structure Standardization subsystem is designed to process and normalize chemical structures, ensuring consistent and chemically correct representations. Its main flow involves cleaning drawing artifacts, handling fragments and isotopes, uncharging molecules, and applying general standardization rules to derive a 'parent' molecule from an input. This is achieved through a core standardization component, a parent molecule generator, a drawing cleanup component, and a molblock processor, all of which may interact with an exclusion flag component to filter out unwanted structures.
+
+
+
+### StandardizationCore
+
+This component encapsulates the fundamental chemical structure standardization algorithms, including valence adjustments, s-group removal, kekulization, hydrogen removal, normalization, uncharging, and specific structural flattening, ensuring molecular data consistency.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/chembl/ChEMBL_Structure_Pipeline/blob/master/chembl_structure_pipeline/standardizer.py#L455-L472" target="_blank" rel="noopener noreferrer">`ChEMBL_Structure_Pipeline.chembl_structure_pipeline.standardizer.standardize_mol` (455:472)</a>
+
+- <a href="https://github.com/chembl/ChEMBL_Structure_Pipeline/blob/master/chembl_structure_pipeline/standardizer.py#L26-L29" target="_blank" rel="noopener noreferrer">`ChEMBL_Structure_Pipeline.chembl_structure_pipeline.standardizer.update_mol_valences` (26:29)</a>
+
+- <a href="https://github.com/chembl/ChEMBL_Structure_Pipeline/blob/master/chembl_structure_pipeline/standardizer.py#L147-L150" target="_blank" rel="noopener noreferrer">`ChEMBL_Structure_Pipeline.chembl_structure_pipeline.standardizer.remove_sgroups_from_mol` (147:150)</a>
+
+- <a href="https://github.com/chembl/ChEMBL_Structure_Pipeline/blob/master/chembl_structure_pipeline/standardizer.py#L21-L23" target="_blank" rel="noopener noreferrer">`ChEMBL_Structure_Pipeline.chembl_structure_pipeline.standardizer.kekulize_mol` (21:23)</a>
+
+- <a href="https://github.com/chembl/ChEMBL_Structure_Pipeline/blob/master/chembl_structure_pipeline/standardizer.py#L75-L144" target="_blank" rel="noopener noreferrer">`ChEMBL_Structure_Pipeline.chembl_structure_pipeline.standardizer.remove_hs_from_mol` (75:144)</a>
+
+- <a href="https://github.com/chembl/ChEMBL_Structure_Pipeline/blob/master/chembl_structure_pipeline/standardizer.py#L62-L72" target="_blank" rel="noopener noreferrer">`ChEMBL_Structure_Pipeline.chembl_structure_pipeline.standardizer.normalize_mol` (62:72)</a>
+
+- <a href="https://github.com/chembl/ChEMBL_Structure_Pipeline/blob/master/chembl_structure_pipeline/standardizer.py#L153-L191" target="_blank" rel="noopener noreferrer">`ChEMBL_Structure_Pipeline.chembl_structure_pipeline.standardizer.uncharge_mol` (153:191)</a>
+
+- <a href="https://github.com/chembl/ChEMBL_Structure_Pipeline/blob/master/chembl_structure_pipeline/standardizer.py#L269-L282" target="_blank" rel="noopener noreferrer">`ChEMBL_Structure_Pipeline.chembl_structure_pipeline.standardizer.flatten_tartrate_mol` (269:282)</a>
+
+
+
+
+
+### ParentMoleculeGenerator
+
+This component is responsible for deriving the parent molecule from a given chemical structure, handling both isotopic and fragmented parent forms. It relies on core standardization utilities and exclusion checks to produce the canonical parent.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/chembl/ChEMBL_Structure_Pipeline/blob/master/chembl_structure_pipeline/standardizer.py#L438-L443" target="_blank" rel="noopener noreferrer">`ChEMBL_Structure_Pipeline.chembl_structure_pipeline.standardizer.get_parent_mol` (438:443)</a>
+
+- <a href="https://github.com/chembl/ChEMBL_Structure_Pipeline/blob/master/chembl_structure_pipeline/standardizer.py#L430-L435" target="_blank" rel="noopener noreferrer">`ChEMBL_Structure_Pipeline.chembl_structure_pipeline.standardizer.get_isotope_parent_mol` (430:435)</a>
+
+- <a href="https://github.com/chembl/ChEMBL_Structure_Pipeline/blob/master/chembl_structure_pipeline/standardizer.py#L290-L427" target="_blank" rel="noopener noreferrer">`ChEMBL_Structure_Pipeline.chembl_structure_pipeline.standardizer.get_fragment_parent_mol` (290:427)</a>
+
+
+
+
+
+### DrawingCleanup
+
+This component specifically addresses and corrects common drawing artifacts in chemical structures, such as misconfigured triple bonds and allenes, to improve the accuracy of molecular representations.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/chembl/ChEMBL_Structure_Pipeline/blob/master/chembl_structure_pipeline/standardizer.py#L252-L266" target="_blank" rel="noopener noreferrer">`ChEMBL_Structure_Pipeline.chembl_structure_pipeline.standardizer.cleanup_drawing_mol` (252:266)</a>
+
+- <a href="https://github.com/chembl/ChEMBL_Structure_Pipeline/blob/master/chembl_structure_pipeline/standardizer.py#L223-L237" target="_blank" rel="noopener noreferrer">`ChEMBL_Structure_Pipeline.chembl_structure_pipeline.standardizer._cleanup_triple_bonds` (223:237)</a>
+
+- <a href="https://github.com/chembl/ChEMBL_Structure_Pipeline/blob/master/chembl_structure_pipeline/standardizer.py#L213-L220" target="_blank" rel="noopener noreferrer">`ChEMBL_Structure_Pipeline.chembl_structure_pipeline.standardizer._check_and_straighten_at_triple_bond` (213:220)</a>
+
+- <a href="https://github.com/chembl/ChEMBL_Structure_Pipeline/blob/master/chembl_structure_pipeline/standardizer.py#L240-L249" target="_blank" rel="noopener noreferrer">`ChEMBL_Structure_Pipeline.chembl_structure_pipeline.standardizer._cleanup_allenes` (240:249)</a>
+
+
+
+
+
+### MolblockProcessor
+
+This component manages the input and output of chemical structures in Molblock format, including parsing, reapplication of wedging information, and orchestrating the standardization and parent molecule generation processes for Molblock data.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/chembl/ChEMBL_Structure_Pipeline/blob/master/chembl_structure_pipeline/standardizer.py#L486-L505" target="_blank" rel="noopener noreferrer">`ChEMBL_Structure_Pipeline.chembl_structure_pipeline.standardizer.parse_molblock` (486:505)</a>
+
+- <a href="https://github.com/chembl/ChEMBL_Structure_Pipeline/blob/master/chembl_structure_pipeline/standardizer.py#L508-L513" target="_blank" rel="noopener noreferrer">`ChEMBL_Structure_Pipeline.chembl_structure_pipeline.standardizer.standardize_molblock` (508:513)</a>
+
+- <a href="https://github.com/chembl/ChEMBL_Structure_Pipeline/blob/master/chembl_structure_pipeline/standardizer.py#L475-L483" target="_blank" rel="noopener noreferrer">`ChEMBL_Structure_Pipeline.chembl_structure_pipeline.standardizer.reapply_molblock_wedging` (475:483)</a>
+
+- <a href="https://github.com/chembl/ChEMBL_Structure_Pipeline/blob/master/chembl_structure_pipeline/standardizer.py#L446-L452" target="_blank" rel="noopener noreferrer">`ChEMBL_Structure_Pipeline.chembl_structure_pipeline.standardizer.get_parent_molblock` (446:452)</a>
+
+
+
+
+
+### ExclusionFlag
+
+This component provides a mechanism to determine if a chemical structure should be excluded from certain processing steps, based on predefined rules or properties, preventing unwanted or invalid structures from proceeding through the pipeline.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/chembl/ChEMBL_Structure_Pipeline/blob/master/chembl_structure_pipeline/exclude_flag.py#L84-L113" target="_blank" rel="noopener noreferrer">`ChEMBL_Structure_Pipeline.chembl_structure_pipeline.exclude_flag.exclude_flag` (84:113)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Structure Validation.md
+++ b/.codeboarding/Structure Validation.md
@@ -1,0 +1,141 @@
+```mermaid
+
+graph LR
+
+    InChI_Generation_Module["InChI Generation Module"]
+
+    InChI_Validation_Module["InChI Validation Module"]
+
+    Stereo_Chemistry_Validation_Module["Stereo Chemistry Validation Module"]
+
+    Molblock_Orchestration_Module["Molblock Orchestration Module"]
+
+    Polymer_Detection_Module["Polymer Detection Module"]
+
+    InChI_Validation_Module -- "uses" --> InChI_Generation_Module
+
+    Stereo_Chemistry_Validation_Module -- "uses" --> InChI_Generation_Module
+
+    Molblock_Orchestration_Module -- "orchestrates" --> InChI_Validation_Module
+
+    Molblock_Orchestration_Module -- "orchestrates" --> Stereo_Chemistry_Validation_Module
+
+    Molblock_Orchestration_Module -- "orchestrates" --> Polymer_Detection_Module
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+The Structure Validation subsystem is responsible for ensuring the integrity and correctness of chemical structures. It orchestrates various specialized modules to perform checks on InChI strings, stereochemistry, and general molblock validity. The main flow involves generating InChI from molblocks, validating the InChI and stereochemical information, detecting polymers, and aggregating all validation results to provide a comprehensive assessment of the chemical structure's quality and identify any inconsistencies.
+
+
+
+### InChI Generation Module
+
+This component is responsible for generating InChI strings and handling associated warnings from molblocks. It serves as a foundational utility for other modules requiring InChI data.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/chembl/ChEMBL_Structure_Pipeline/blob/master/chembl_structure_pipeline/checker.py#L41-L48" target="_blank" rel="noopener noreferrer">`ChEMBL_Structure_Pipeline.chembl_structure_pipeline.checker.get_inchi` (41:48)</a>
+
+- <a href="https://github.com/chembl/ChEMBL_Structure_Pipeline/blob/master/chembl_structure_pipeline/checker.py#L20-L22" target="_blank" rel="noopener noreferrer">`ChEMBL_Structure_Pipeline.chembl_structure_pipeline.checker._get_molblock_inchi_and_warnings` (20:22)</a>
+
+
+
+
+
+### InChI Validation Module
+
+This component provides functionalities to validate InChI strings and calculate a score based on the warnings generated during InChI creation, indicating the quality or issues with the InChI.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/chembl/ChEMBL_Structure_Pipeline/blob/master/chembl_structure_pipeline/checker.py#L65-L70" target="_blank" rel="noopener noreferrer">`ChEMBL_Structure_Pipeline.chembl_structure_pipeline.checker.InchiChecker.check` (65:70)</a>
+
+- <a href="https://github.com/chembl/ChEMBL_Structure_Pipeline/blob/master/chembl_structure_pipeline/checker.py#L73-L117" target="_blank" rel="noopener noreferrer">`ChEMBL_Structure_Pipeline.chembl_structure_pipeline.checker.InchiChecker.get_inchi_score` (73:117)</a>
+
+
+
+
+
+### Stereo Chemistry Validation Module
+
+This component focuses on analyzing and scoring the stereochemical information present in molblocks by comparing different stereo counts derived from InChI, Mol, and RDKit, identifying potential discrepancies.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/chembl/ChEMBL_Structure_Pipeline/blob/master/chembl_structure_pipeline/checker.py#L127-L177" target="_blank" rel="noopener noreferrer">`ChEMBL_Structure_Pipeline.chembl_structure_pipeline.checker.StereoChecker.get_stereo_counts` (127:177)</a>
+
+- <a href="https://github.com/chembl/ChEMBL_Structure_Pipeline/blob/master/chembl_structure_pipeline/checker.py#L180-L186" target="_blank" rel="noopener noreferrer">`ChEMBL_Structure_Pipeline.chembl_structure_pipeline.checker.StereoChecker.check` (180:186)</a>
+
+- <a href="https://github.com/chembl/ChEMBL_Structure_Pipeline/blob/master/chembl_structure_pipeline/checker.py#L189-L199" target="_blank" rel="noopener noreferrer">`ChEMBL_Structure_Pipeline.chembl_structure_pipeline.checker.StereoChecker.get_stereo_score` (189:199)</a>
+
+
+
+
+
+### Molblock Orchestration Module
+
+This is the primary entry point for comprehensive molblock validation. It orchestrates various checks from specialized checker modules, including InChI, stereo, and polymer checks, and aggregates their results to provide an overall validation status.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/chembl/ChEMBL_Structure_Pipeline/blob/master/chembl_structure_pipeline/checker.py#L486-L509" target="_blank" rel="noopener noreferrer">`ChEMBL_Structure_Pipeline.chembl_structure_pipeline.checker.check_molblock` (486:509)</a>
+
+
+
+
+
+### Polymer Detection Module
+
+This specialized component is responsible for checking the presence of polymer-related patterns within the molblock data, indicating if the structure represents a polymer.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/chembl/ChEMBL_Structure_Pipeline/blob/master/chembl_structure_pipeline/checker.py#L452-L453" target="_blank" rel="noopener noreferrer">`ChEMBL_Structure_Pipeline.chembl_structure_pipeline.checker.PolymerFileChecker.check` (452:453)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/on_boarding.md
+++ b/.codeboarding/on_boarding.md
@@ -1,0 +1,143 @@
+```mermaid
+
+graph LR
+
+    Structure_Validation["Structure Validation"]
+
+    Structure_Standardization["Structure Standardization"]
+
+    Exclusion_Flag_Utility["Exclusion Flag Utility"]
+
+    Structure_Standardization -- "uses" --> Exclusion_Flag_Utility
+
+    click Structure_Validation href "https://github.com/chembl/ChEMBL_Structure_Pipeline/blob/main/.codeboarding//Structure Validation.md" "Details"
+
+    click Structure_Standardization href "https://github.com/chembl/ChEMBL_Structure_Pipeline/blob/main/.codeboarding//Structure Standardization.md" "Details"
+
+    click Exclusion_Flag_Utility href "https://github.com/chembl/ChEMBL_Structure_Pipeline/blob/main/.codeboarding//Exclusion Flag Utility.md" "Details"
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+This graph represents the core functionality of the ChEMBL Structure Pipeline, which is designed to process and manage chemical structures. The main flow involves validating incoming chemical structures for integrity and correctness, standardizing them to a consistent and chemically sound representation, and then applying exclusion rules to filter out undesirable structures. This ensures that only high-quality, standardized chemical data is maintained within the system.
+
+
+
+### Structure Validation
+
+This component is responsible for validating chemical structures and their properties. It includes checks for InChI integrity, stereochemistry, and general molblock validity, identifying potential issues or inconsistencies in the structural representation. It also provides scoring based on the severity of identified issues.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/chembl/ChEMBL_Structure_Pipeline/blob/master/chembl_structure_pipeline/checker.py#L41-L48" target="_blank" rel="noopener noreferrer">`ChEMBL_Structure_Pipeline.chembl_structure_pipeline.checker.get_inchi` (41:48)</a>
+
+- <a href="https://github.com/chembl/ChEMBL_Structure_Pipeline/blob/master/chembl_structure_pipeline/checker.py#L20-L22" target="_blank" rel="noopener noreferrer">`ChEMBL_Structure_Pipeline.chembl_structure_pipeline.checker._get_molblock_inchi_and_warnings` (20:22)</a>
+
+- <a href="https://github.com/chembl/ChEMBL_Structure_Pipeline/blob/master/chembl_structure_pipeline/checker.py#L65-L70" target="_blank" rel="noopener noreferrer">`ChEMBL_Structure_Pipeline.chembl_structure_pipeline.checker.InchiChecker.check` (65:70)</a>
+
+- <a href="https://github.com/chembl/ChEMBL_Structure_Pipeline/blob/master/chembl_structure_pipeline/checker.py#L73-L117" target="_blank" rel="noopener noreferrer">`ChEMBL_Structure_Pipeline.chembl_structure_pipeline.checker.InchiChecker.get_inchi_score` (73:117)</a>
+
+- <a href="https://github.com/chembl/ChEMBL_Structure_Pipeline/blob/master/chembl_structure_pipeline/checker.py#L127-L177" target="_blank" rel="noopener noreferrer">`ChEMBL_Structure_Pipeline.chembl_structure_pipeline.checker.StereoChecker.get_stereo_counts` (127:177)</a>
+
+- <a href="https://github.com/chembl/ChEMBL_Structure_Pipeline/blob/master/chembl_structure_pipeline/checker.py#L180-L186" target="_blank" rel="noopener noreferrer">`ChEMBL_Structure_Pipeline.chembl_structure_pipeline.checker.StereoChecker.check` (180:186)</a>
+
+- <a href="https://github.com/chembl/ChEMBL_Structure_Pipeline/blob/master/chembl_structure_pipeline/checker.py#L189-L199" target="_blank" rel="noopener noreferrer">`ChEMBL_Structure_Pipeline.chembl_structure_pipeline.checker.StereoChecker.get_stereo_score` (189:199)</a>
+
+- <a href="https://github.com/chembl/ChEMBL_Structure_Pipeline/blob/master/chembl_structure_pipeline/checker.py#L486-L509" target="_blank" rel="noopener noreferrer">`ChEMBL_Structure_Pipeline.chembl_structure_pipeline.checker.check_molblock` (486:509)</a>
+
+- <a href="https://github.com/chembl/ChEMBL_Structure_Pipeline/blob/master/chembl_structure_pipeline/checker.py#L452-L453" target="_blank" rel="noopener noreferrer">`ChEMBL_Structure_Pipeline.chembl_structure_pipeline.checker.PolymerFileChecker.check` (452:453)</a>
+
+
+
+
+
+### Structure Standardization
+
+This component focuses on processing and normalizing chemical structures. It performs various operations such as cleaning up drawing artifacts, handling fragments and isotopes, uncharging molecules, and applying general standardization rules to ensure consistent and chemically correct representations. It aims to derive a 'parent' molecule from a given input.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/chembl/ChEMBL_Structure_Pipeline/blob/master/chembl_structure_pipeline/standardizer.py#L223-L237" target="_blank" rel="noopener noreferrer">`ChEMBL_Structure_Pipeline.chembl_structure_pipeline.standardizer._cleanup_triple_bonds` (223:237)</a>
+
+- <a href="https://github.com/chembl/ChEMBL_Structure_Pipeline/blob/master/chembl_structure_pipeline/standardizer.py#L213-L220" target="_blank" rel="noopener noreferrer">`ChEMBL_Structure_Pipeline.chembl_structure_pipeline.standardizer._check_and_straighten_at_triple_bond` (213:220)</a>
+
+- <a href="https://github.com/chembl/ChEMBL_Structure_Pipeline/blob/master/chembl_structure_pipeline/standardizer.py#L240-L249" target="_blank" rel="noopener noreferrer">`ChEMBL_Structure_Pipeline.chembl_structure_pipeline.standardizer._cleanup_allenes` (240:249)</a>
+
+- <a href="https://github.com/chembl/ChEMBL_Structure_Pipeline/blob/master/chembl_structure_pipeline/standardizer.py#L252-L266" target="_blank" rel="noopener noreferrer">`ChEMBL_Structure_Pipeline.chembl_structure_pipeline.standardizer.cleanup_drawing_mol` (252:266)</a>
+
+- <a href="https://github.com/chembl/ChEMBL_Structure_Pipeline/blob/master/chembl_structure_pipeline/standardizer.py#L290-L427" target="_blank" rel="noopener noreferrer">`ChEMBL_Structure_Pipeline.chembl_structure_pipeline.standardizer.get_fragment_parent_mol` (290:427)</a>
+
+- <a href="https://github.com/chembl/ChEMBL_Structure_Pipeline/blob/master/chembl_structure_pipeline/standardizer.py#L153-L191" target="_blank" rel="noopener noreferrer">`ChEMBL_Structure_Pipeline.chembl_structure_pipeline.standardizer.uncharge_mol` (153:191)</a>
+
+- <a href="https://github.com/chembl/ChEMBL_Structure_Pipeline/blob/master/chembl_structure_pipeline/standardizer.py#L430-L435" target="_blank" rel="noopener noreferrer">`ChEMBL_Structure_Pipeline.chembl_structure_pipeline.standardizer.get_isotope_parent_mol` (430:435)</a>
+
+- <a href="https://github.com/chembl/ChEMBL_Structure_Pipeline/blob/master/chembl_structure_pipeline/standardizer.py#L75-L144" target="_blank" rel="noopener noreferrer">`ChEMBL_Structure_Pipeline.chembl_structure_pipeline.standardizer.remove_hs_from_mol` (75:144)</a>
+
+- <a href="https://github.com/chembl/ChEMBL_Structure_Pipeline/blob/master/chembl_structure_pipeline/standardizer.py#L438-L443" target="_blank" rel="noopener noreferrer">`ChEMBL_Structure_Pipeline.chembl_structure_pipeline.standardizer.get_parent_mol` (438:443)</a>
+
+- <a href="https://github.com/chembl/ChEMBL_Structure_Pipeline/blob/master/chembl_structure_pipeline/standardizer.py#L475-L483" target="_blank" rel="noopener noreferrer">`ChEMBL_Structure_Pipeline.chembl_structure_pipeline.standardizer.reapply_molblock_wedging` (475:483)</a>
+
+- <a href="https://github.com/chembl/ChEMBL_Structure_Pipeline/blob/master/chembl_structure_pipeline/standardizer.py#L446-L452" target="_blank" rel="noopener noreferrer">`ChEMBL_Structure_Pipeline.chembl_structure_pipeline.standardizer.get_parent_molblock` (446:452)</a>
+
+- <a href="https://github.com/chembl/ChEMBL_Structure_Pipeline/blob/master/chembl_structure_pipeline/standardizer.py#L455-L472" target="_blank" rel="noopener noreferrer">`ChEMBL_Structure_Pipeline.chembl_structure_pipeline.standardizer.standardize_mol` (455:472)</a>
+
+- <a href="https://github.com/chembl/ChEMBL_Structure_Pipeline/blob/master/chembl_structure_pipeline/standardizer.py#L26-L29" target="_blank" rel="noopener noreferrer">`ChEMBL_Structure_Pipeline.chembl_structure_pipeline.standardizer.update_mol_valences` (26:29)</a>
+
+- <a href="https://github.com/chembl/ChEMBL_Structure_Pipeline/blob/master/chembl_structure_pipeline/standardizer.py#L147-L150" target="_blank" rel="noopener noreferrer">`ChEMBL_Structure_Pipeline.chembl_structure_pipeline.standardizer.remove_sgroups_from_mol` (147:150)</a>
+
+- <a href="https://github.com/chembl/ChEMBL_Structure_Pipeline/blob/master/chembl_structure_pipeline/standardizer.py#L21-L23" target="_blank" rel="noopener noreferrer">`ChEMBL_Structure_Pipeline.chembl_structure_pipeline.standardizer.kekulize_mol` (21:23)</a>
+
+- <a href="https://github.com/chembl/ChEMBL_Structure_Pipeline/blob/master/chembl_structure_pipeline/standardizer.py#L62-L72" target="_blank" rel="noopener noreferrer">`ChEMBL_Structure_Pipeline.chembl_structure_pipeline.standardizer.normalize_mol` (62:72)</a>
+
+- <a href="https://github.com/chembl/ChEMBL_Structure_Pipeline/blob/master/chembl_structure_pipeline/standardizer.py#L269-L282" target="_blank" rel="noopener noreferrer">`ChEMBL_Structure_Pipeline.chembl_structure_pipeline.standardizer.flatten_tartrate_mol` (269:282)</a>
+
+- <a href="https://github.com/chembl/ChEMBL_Structure_Pipeline/blob/master/chembl_structure_pipeline/standardizer.py#L486-L505" target="_blank" rel="noopener noreferrer">`ChEMBL_Structure_Pipeline.chembl_structure_pipeline.standardizer.parse_molblock` (486:505)</a>
+
+- <a href="https://github.com/chembl/ChEMBL_Structure_Pipeline/blob/master/chembl_structure_pipeline/standardizer.py#L508-L513" target="_blank" rel="noopener noreferrer">`ChEMBL_Structure_Pipeline.chembl_structure_pipeline.standardizer.standardize_molblock` (508:513)</a>
+
+
+
+
+
+### Exclusion Flag Utility
+
+This utility provides a function to determine if a chemical structure should be excluded based on predefined criteria or flags, often used during the standardization process to filter out undesirable structures.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/chembl/ChEMBL_Structure_Pipeline/blob/master/chembl_structure_pipeline/exclude_flag.py#L84-L113" target="_blank" rel="noopener noreferrer">`ChEMBL_Structure_Pipeline.chembl_structure_pipeline.exclude_flag.exclude_flag` (84:113)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)


### PR DESCRIPTION
This PR contains high-level diagrams for the [ChEMBL_Structure_Pipeline](https://github.com/chembl/ChEMBL_Structure_Pipeline) codebase. You can see how they render in Github here:
https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/ChEMBL_Structure_Pipelinec/on_boarding.md

These diagrams are designed to help people quickly understand a codebase. I believe many scientists look into this codebase. Our goal is to reduce the time it takes them to get up to speed—from hours to just minutes—by using visuals (diagrams) instead of reading through the entire code. I'd love to hear where do stand on diagram first documentation for codbases!

We’d love any feedback! We also just released a free GitHub Action that can automatically update the docs.

Full disclosure: we're trying to turn this into a startup, but we're still in a very early stage and figuring out what will actually be useful for people.