### PR TITLE
suppress atom.GetImplicitValence deprecation warning from rdkit Release_2025.09.1

### DIFF
--- a/chembl_structure_pipeline/standardizer.py
+++ b/chembl_structure_pipeline/standardizer.py
@@ -112,7 +112,7 @@ def remove_hs_from_mol(m):
             else:
                 is_protonated = (
                     nbr.GetFormalCharge() == 1
-                    and nbr.GetExplicitValence()
+                    and nbr.GetValence(Chem.ValenceType.EXPLICIT)
                     == Chem.GetPeriodicTable().GetDefaultValence(nbr.GetAtomicNum()) + 1
                 )
                 if nbr.GetChiralTag() in (
@@ -122,7 +122,7 @@ def remove_hs_from_mol(m):
                     preserve = True
                 elif not is_protonated:
                     if (
-                        nbr.GetExplicitValence()
+                        nbr.GetValence(Chem.ValenceType.EXPLICIT)
                         > Chem.GetPeriodicTable().GetDefaultValence(nbr.GetAtomicNum())
                     ):
                         preserve = True


### PR DESCRIPTION
The warning looks like this;
```txt
[12:03:35] DEPRECATION WARNING: please use GetValence(which=)
```
The commit fixes it. To test, run:
```shell
python -c 'from rdkit import Chem; from chembl_structure_pipeline import standardizer; mol = Chem.MolFromSmiles("CCCCCC"); standardizer.standardize_mol(mol)'
```

Check the release notes for the deprecation:
https://github.com/rdkit/rdkit/blob/master/ReleaseNotes.md#:~:text=Replace%20GetImplicitValence()%20and%20GetExplicitValence()%20with%20GetValence()%20(github%20pull%20%237926%20from%20greglandrum)